### PR TITLE
Bump text upper version bounds

### DIFF
--- a/vcswrapper/vcswrapper.cabal
+++ b/vcswrapper/vcswrapper.cabal
@@ -28,7 +28,7 @@ library
                process >=1.0.1.5 && <1.3,
                filepath >=1.2.0.0 && < 1.4,
                split >=0.2.2 && <0.3,
-               text >=0.11.1.5 && <1.2
+               text >=0.11.1.5 && <1.3
     exposed-modules: VCSWrapper.Common VCSWrapper.Git VCSWrapper.Svn VCSWrapper.Mercurial
     other-modules:
                VCSWrapper.Svn.Types VCSWrapper.Svn.Process VCSWrapper.Svn.Parsers
@@ -51,7 +51,7 @@ executable vcswrapper
                process >=1.0.1.5 && <1.3,
                filepath >=1.2.0.0 && < 1.4,
                split >=0.2.2 && <0.3,
-               text >=0.11.1.5 && <1.2
+               text >=0.11.1.5 && <1.3
     buildable: True
     hs-source-dirs: src
     other-modules:


### PR DESCRIPTION
Increase the upper version bounds of packages to accommodate the most recent versions. This is a part of my effort to get `leksah` to install using the latest libraries.
