### PR TITLE
fixing for mtl-2.3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+vcswrapper/dist-newstyle/
 *~
 vcswrapper.lkshs
 vcswrapper.lkshw

--- a/vcswrapper/src/VCSWrapper/Common/Process.hs
+++ b/vcswrapper/src/VCSWrapper/Common/Process.hs
@@ -25,7 +25,8 @@ import System.Environment (getEnvironment)
 import System.Exit
 import System.IO (Handle, hFlush, hClose, hGetContents, hPutStr)
 import Control.Concurrent
-import Control.Monad.Reader (ask, liftIO, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (ask)
 import qualified Control.Exception as Exc
 import VCSWrapper.Common.Types
 import Data.Maybe
@@ -33,7 +34,7 @@ import Data.Monoid (mconcat)
 import Data.Text (Text)
 import qualified Data.Text as T (null, unpack, pack)
 import qualified Data.Map.Strict as Map
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Control.Exception (IOException, try)
 
 -- | Internal function to execute a VCS command. Throws an exception if the command fails.

--- a/vcswrapper/vcswrapper.cabal
+++ b/vcswrapper/vcswrapper.cabal
@@ -28,16 +28,16 @@ library
         VCSWrapper.Mercurial
         VCSWrapper.Git.Safe
     build-depends:
-        base >=4.0.0.0 && <4.10,
-        containers >=0.5.5.1 && <0.6,
+        base >=4.0.0.0 && <5,
+        containers >=0.5.5.1 && <0.9,
         directory >=1.1.0.0 && <1.4,
         hxt >=9.1.2 && <9.4,
-        mtl >=2.0.1.0 && <2.3,
+        mtl >=2.0.1.0 && <2.4,
         parsec >=3.1.1 && <3.2,
-        process >=1.0.1.5 && <1.5,
+        process >=1.0.1.5 && <1.7,
         filepath >=1.2.0.0 && <1.5,
         split >=0.2.2 && <0.3,
-        text >=0.11.1.5 && <1.3
+        text >=0.11.1.5 && <2.2
     hs-source-dirs: src
     other-modules:
         VCSWrapper.Svn.Types
@@ -57,16 +57,16 @@ library
 executable vcswrapper
     main-is: Main.hs
     build-depends:
-        base >=4.0.0.0 && <4.10,
-        containers >=0.5.5.1 && <0.6,
+        base >=4.0.0.0 && <5,
+        containers >=0.5.5.1 && <0.9,
         directory >=1.1.0.0 && <1.4,
         hxt >=9.1.2 && <9.4,
-        mtl >=2.0.1.0 && <2.3,
+        mtl >=2.0.1.0 && <2.4,
         parsec >=3.1.1 && <3.2,
-        process >=1.0.1.5 && <1.5,
+        process >=1.0.1.5 && <1.7,
         filepath >=1.2.0.0 && <1.5,
         split >=0.2.2 && <0.3,
-        text >=0.11.1.5 && <1.3
+        text >=0.11.1.5 && <2.2
     hs-source-dirs: src
     other-modules:
         VCSWrapper.Svn.Types


### PR DESCRIPTION
Surprisingly, very little is needed to keep this package to compile with recent versions of ghc/mtl/…